### PR TITLE
Fix type check for JSX children

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -5,4 +5,7 @@ declare namespace JSX {
   interface ElementClass {
     render: any
   }
+  interface ElementChildrenAttribute {
+    children: any;
+  }
 }


### PR DESCRIPTION
Hi, thank you for developing this exciting library!

I hope this "SSR First Approach" and "Partial Hydration"  will greatly improve web development in terms of output size and development experience.


I found that type checking for children of function components was broken.  This seems to be caused by the lack of JSX.ElementChildrenAttribute declaration.

https://www.typescriptlang.org/docs/handbook/jsx.html#children-type-checking

![image](https://user-images.githubusercontent.com/34891695/130330978-7c324741-d995-40fb-a3e8-ddae614b72ee.png)


Once I added that, the error got resolved:

![image](https://user-images.githubusercontent.com/34891695/130331030-312a8a40-f4a0-4cd1-bc23-c7dd59601580.png)


Also, type checking works properly:

![image](https://user-images.githubusercontent.com/34891695/130331039-b1bc03c7-e925-4762-9a65-72d56aebc0f4.png)
(`children` was declared as number, but passed "h1", string )