### PR TITLE
Fix: more strict types for useState

### DIFF
--- a/src/hooks/useState.ts
+++ b/src/hooks/useState.ts
@@ -1,11 +1,11 @@
 import { _state } from '../state'
 
-export const useState = (state: any, id: string) => {
+export const useState = <T>(state: T, id: string): readonly [T, (state: T) => void] => {
   const s = {
-    setState(state: any) {
+    setState(state: T) {
       if (state !== null) _state.set(id, state)
     },
-    get state() {
+    get state(): T {
       return _state.get(id)
     }
   }

--- a/test/hooks/useState.test.tsx
+++ b/test/hooks/useState.test.tsx
@@ -6,7 +6,7 @@ import { setTimeout } from 'timers'
 const spy = jest.spyOn(global.console, 'error')
 
 test('should render without errors', async () => {
-  let _value0 = ''
+  let _value0: string | null = ''
   let _value1 = ''
 
   const Child = () => {
@@ -14,7 +14,7 @@ test('should render without errors', async () => {
     const [random, setRandom] = useState('random', 'Child_Component')
 
     // access the state of App_Component
-    const [value, setValue] = useState(null, 'App_Component')
+    const [value, setValue] = useState<string | null>(null, 'App_Component')
     _value0 = value
 
     const newValue = 'new state'


### PR DESCRIPTION
proposal: https://github.com/nanojsx/nano/discussions/23

## Motivation

I implemented more strict types for `useState`. 
The state returned by `useState` will be inferred with `useState`'s argument or type Parameter, not be inferred as `any`.