### PR TITLE
Fix: more strict type for <Link />

### DIFF
--- a/src/components/link.ts
+++ b/src/components/link.ts
@@ -3,12 +3,20 @@ import { Helmet } from './helmet'
 import { h } from '../core'
 import { Fragment } from '../fragment'
 
+interface Props {
+  [key: string]: any
+  prefetch?: boolean | 'hover' | 'visible'
+  href: string
+  back?: boolean
+  delay?: number
+}
+
 /**
  * A simple Link component
  * Add <Link prefetch ..., to prefetch the html document
  * Add <Link prefetch="hover" ..., to prefetch the html document on hovering over the link element.
  */
-export class Link extends Component {
+export class Link extends Component<Props> {
   prefetchOnHover() {
     this.elements[0].addEventListener('mouseover', () => this.addPrefetch(), { once: true })
   }


### PR DESCRIPTION
## Motivation

I implement the more strict type for `<Link />` component for developer experience.
If you don't think this is needed, please feel free to close PR.