### PR TITLE
Fix: more strict type for <Img /> component

### DIFF
--- a/src/components/img.ts
+++ b/src/components/img.ts
@@ -1,7 +1,22 @@
 import { Component } from '../component'
 import { h, strToHash } from '../core'
 
-export class Img extends Component {
+interface Props {
+  [key: string]: any
+  src: string
+  height?: number | string
+  width?: number | string
+  lazy?: boolean
+  placeholder?: any
+}
+
+/**
+ * A useful Image component
+ * Add <Img lazy ..., to lazy load the img source
+ * Add <Img width="100" height="100" ..., to specify img element's size.
+ * Add <Img placeholder="src or element" ...., to prepare placeholder for img.
+ */
+export class Img extends Component<Props> {
   constructor(props: any) {
     super(props)
 


### PR DESCRIPTION
I implement the more strict type for `<Img />` component for developer experience.
If you don't think this is needed, please feel free to close PR.