### PR TITLE
Fix: more strict type for Functional Component

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -1,7 +1,7 @@
 declare const isSSR: boolean
 
 export interface FC<P = {}> {
-  (props: P): any
+  (props: P): Element | void
   // (props: P, context?: any): any
 }
 


### PR DESCRIPTION
## Motivation

I implemented more strict type for `FC` (functional component) for developer experience