### PR TITLE
Feature: support new JSX Transform API

### DIFF
--- a/jsx-runtime.d.ts
+++ b/jsx-runtime.d.ts
@@ -1,0 +1,1 @@
+export * from "./lib/jsx-runtime/"

--- a/package.json
+++ b/package.json
@@ -34,12 +34,8 @@
   },
   "exports": {
     ".": "./lib/index.js",
-    "./jsx-runtime": "./lib/jsx-runtime/index.js"
-  },
-  "typesVersions": {
-    "*": {
-      "*": [ "./lib/*", "./lib/index.d.ts" ]
-    }
+    "./jsx-runtime": "./lib/jsx-runtime/index.js",
+    "./*": "./*"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "exports": {
     ".": "./lib/index.js",
     "./jsx-runtime": "./lib/jsx-runtime/index.js",
+    "./jsx-dev-runtime": "./lib/jsx-runtime/index.js",
     "./*": "./*"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,15 @@
     "prepareRelease": "npm run clean && npm i && npm run build && npm run bundle && npm run denoify && npm run test && npm run deno:test",
     "test": "npm run clean:test && tsc --project test/tsconfig.json && jest \"test/.+\\.test.js$\" && npm run clean:test"
   },
+  "exports": {
+    ".": "./lib/index.js",
+    "./jsx-runtime": "./lib/jsx-runtime/index.js"
+  },
+  "typesVersions": {
+    "*": {
+      "*": [ "./lib/*", "./lib/index.d.ts" ]
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nanojsx/nano.git"

--- a/src/jsx-runtime/index.ts
+++ b/src/jsx-runtime/index.ts
@@ -1,13 +1,11 @@
 export { Fragment } from '../fragment'
 import { h } from '../core'
 
-const createNode: (type: any, props: any, key: string, source?: string, self?: string) => any = function (
-  type,
-  props
-) {
-    return h(type, props, props?.children ?? []);
+const createNode: (type: any, props: any, key: string, source?: string, self?: string) => any = function (type, props) {
+  const { children, ..._props } = props
+  return h(type, _props, children ?? [])
 }
 
-export { createNode as jsx };
-export { createNode as jsxs };
-export { createNode as jsxDev };
+export { createNode as jsx }
+export { createNode as jsxs }
+export { createNode as jsxDev }

--- a/src/jsx-runtime/index.ts
+++ b/src/jsx-runtime/index.ts
@@ -1,0 +1,13 @@
+export { Fragment } from '../fragment'
+import { h } from '../core'
+
+const createNode: (type: any, props: any, key: string, source?: string, self?: string) => any = function (
+  type,
+  props
+) {
+    return h(type, props, props?.children ?? []);
+}
+
+export { createNode as jsx };
+export { createNode as jsxs };
+export { createNode as jsxDev };

--- a/test/jsx-runtime.test.tsx
+++ b/test/jsx-runtime.test.tsx
@@ -1,0 +1,32 @@
+import Nano from '../lib/index.js'
+import { jsx } from '../lib/jsx-runtime/index.js'
+import { wait, nodeToString } from './helpers.js'
+
+const spy = jest.spyOn(global.console, 'error')
+
+test('should render without errors', async () => {
+  const Root = () => {
+    return jsx(
+      'div',
+      {
+        id: 'root',
+        children: [
+          jsx(
+            'h1',
+            {
+              children: ['Hello']
+            },
+            'bar'
+          )
+        ]
+      },
+      'hoge'
+    )
+  }
+
+  const res = Nano.render(Root)
+
+  await wait()
+  expect(nodeToString(res)).toBe('<div id="root"><h1>Hello</h1></div>')
+  expect(spy).not.toHaveBeenCalled()
+})


### PR DESCRIPTION
## Motivation

Fix: #21 

Hi! Currently, tsc, swc, babel, flow ... transpile JSX into new factory function imported from `{library}/jsx-runtime` with the specific configuration.

For example in tsc, with `{ "jsx": "react-jsx", "jsxImportSource": "nano-jsx" }` will insert import declaration `import { jsx } from "nano-jsx/jsx-runtime"` and transpile JSX into jsx function call.

I made a support for this.

## What I did

* I implemented `createNode` function in `./lib/jsx-runtime`. This will simply pass args into h function(because nanojsx has no vdom, so `createNode` function acts as a simple mediator for `h` function), and export `createNode` as jsx, jsxs, jsxDev.

* export `Fragment` also from `./lib/jsx-runtime`

* I make subpath alias for `nano-jsx/jsx-runtime` for `nano-jsx/lib/jsx-runtime/index.js` with `exports` field in package.json

If you have something unclear or wrong, feel free to point out it.