### PR TITLE
Feat: render empty on false

### DIFF
--- a/deno_lib/core.ts
+++ b/deno_lib/core.ts
@@ -125,6 +125,9 @@ export const _render = (comp: any): any => {
   // null
   if (comp == null) return []
 
+  // false
+  if (comp === false) return []
+
   // string
   if (typeof comp === 'string') return comp
 

--- a/src/core.ts
+++ b/src/core.ts
@@ -125,6 +125,9 @@ export const _render = (comp: any): any => {
   // null
   if (comp == null) return []
 
+  // false
+  if (comp === false) return []
+
   // string
   if (typeof comp === 'string') return comp
 


### PR DESCRIPTION
Here is a common practice for conditional rendering in JSX:

```jsx
// Mailbox.jsx
// Example from React Documents: https://reactjs.org/docs/conditional-rendering.html#inline-if-with-logical--operator
export function Mailbox(props) {
  const unreadMessages = props.unreadMessages;
  return (
    <div>
      <h1>Hello!</h1>
      {unreadMessages.length > 0 &&
        <h2>
          You have {unreadMessages.length} unread messages.
        </h2>
      }
    </div>
  );
}
```

This PR makes `Nano JSX` treats `false` as allowed `comp` and simply returns an empty `[]` instead of giving `Something unexpected happened with: false` warning.