### PR TITLE
Feature: add useContext on Context API

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -14,8 +14,8 @@ export const createContext = (ctx: any) => {
 }
 
 export const useContext = (ctx: any) => {
-  let _ctx = ctx
-  if (_ctx && typeof(_ctx.get) == "function") {
+  const _ctx = ctx
+  if (_ctx && typeof _ctx.get === 'function') {
     return _ctx.get()
   }
 }

--- a/src/context.ts
+++ b/src/context.ts
@@ -12,3 +12,10 @@ export const createContext = (ctx: any) => {
     set: (ctx: any) => (_ctx = ctx)
   }
 }
+
+export const useContext = (ctx: any) => {
+  let _ctx = ctx
+  if (_ctx && typeof(_ctx.get) == "function") {
+    return _ctx.get()
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ export { nodeToString, task } from './helpers'
 export { renderSSR } from './ssr'
 export { Fragment } from './fragment'
 export { Store } from './store'
-export { createContext } from './context'
+export { createContext, useContext } from './context'
 export { withStyles } from './withStyles'
 export { defineAsCustomElements } from './customElementsMode'
 

--- a/test/nodejs/context.test.tsx
+++ b/test/nodejs/context.test.tsx
@@ -1,4 +1,4 @@
-import Nano, { Component, Fragment, createContext } from '../../lib/index.js'
+import Nano, { Component, Fragment, createContext, useContext } from '../../lib/index.js'
 import { wait, nodeToString } from './helpers.js'
 
 const spy = jest.spyOn(global.console, 'error')
@@ -74,6 +74,81 @@ test('should render without errors', async () => {
       <MyContext.Provider value={props.name}>
         <Child />
       </MyContext.Provider>
+    )
+  }
+
+  const res = Nano.render(
+    <div id="root">
+      <Parent name="john" />
+    </div>
+  )
+
+  await wait()
+  expect(nodeToString(res)).toBe('<div id="root"><p>john</p></div>')
+  expect(spy).not.toHaveBeenCalled()
+})
+
+test('should render without errors', async () => {
+  const UserContext = createContext('Unknown');
+
+  class Child extends Component {
+    render() {
+      if (useContext(UserContext) === 'yannick') UserContext.set('aika')
+      const value = useContext(UserContext)
+
+      return <p>{value}</p>
+    }
+  }
+
+  class Parent extends Component {
+    render() {
+      return (
+        <UserContext.Provider value={this.props.name}>
+          <Child />
+        </UserContext.Provider>
+      )
+    }
+  }
+
+  // render
+  let res = Nano.render(
+    <div id="root">
+      <Parent name="suzanne" />
+    </div>
+  )
+  await wait()
+  expect(nodeToString(res)).toBe('<div id="root"><p>suzanne</p></div>')
+  expect(spy).not.toHaveBeenCalled()
+
+  // render again and change the context in didMount()
+  res = Nano.render(
+    <div id="root">
+      <Parent name="yannick" />
+    </div>
+  )
+  await wait()
+  expect(nodeToString(res)).toBe('<div id="root"><p>aika</p></div>')
+  expect(spy).not.toHaveBeenCalled()
+
+  // set/get context outside components
+  expect(useContext(UserContext)).toBe('aika')
+  UserContext.set('tom')
+  expect(useContext(UserContext)).toBe('tom')
+})
+
+test('should render without errors', async () => {
+  const UserContext = createContext('suzanne')
+
+  const Child = () => {
+    const value = useContext(UserContext)
+    return <p>{value}</p>
+  }
+
+  const Parent = (props: any) => {
+    return (
+      <UserContext.Provider value={props.name}>
+        <Child />
+      </UserContext.Provider>
     )
   }
 


### PR DESCRIPTION
### Reference Issues/PRs

None

### What does this implement/fix?

Added `useContext` on Context API to provide better developer experience.
As alternative for `MyContext.get()` you can now use `useContext(MyContext)`.