### PR TITLE
Expose sub-paths for CDN's

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,12 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "type": "commonjs",
-  "exports": {
-    ".": "./lib/index.js",
-    "./hooks/useState":"./lib/hooks/useState.js",
-    "./htm": "./lib/htm.js",
-    "./jsx-runtime": "./lib/jsx-runtime/index.js",
-    "./ui": "./lib/ui/index.js"
+  "browser": {
+    "./lib/index.js": "./lib/index.js",
+    "./lib/hooks/useState":"./lib/hooks/useState.js",
+    "./lib/htm": "./lib/htm.js",
+    "./lib/jsx-runtime": "./lib/jsx-runtime/index.js",
+    "./lib/ui": "./lib/ui/index.js"
   },
   "scripts": {
     "start": "npm run dev",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "browser": {
     "./lib/index.js": "./lib/index.js",
     "./lib/hooks/useState":"./lib/hooks/useState.js",
-    "./lib/htm": "./lib/htm.js",
+    "./lib/htm": "./lib/htm/index.js",
     "./lib/jsx-runtime": "./lib/jsx-runtime/index.js",
     "./lib/ui": "./lib/ui/index.js"
   },

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
   "type": "commonjs",
   "browser": {
     "./lib/index.js": "./lib/index.js",
-    "./lib/hooks/useState":"./lib/hooks/useState.js",
+    "./lib/hooks":"./lib/hooks/index.js",
     "./lib/htm": "./lib/htm/index.js",
     "./lib/jsx-runtime": "./lib/jsx-runtime/index.js",
-    "./lib/ui": "./lib/ui/index.js"
+    "./lib/ui": "./lib/ui/index.js",
+    "./lib/components": "./lib/components/index.js"
   },
   "scripts": {
     "start": "npm run dev",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,13 @@
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "type": "commonjs",
+  "exports": {
+    ".": "./lib/index.js",
+    "./hooks/useState":"./lib/hooks/useState.js",
+    "./htm": "./lib/htm.js",
+    "./jsx-runtime": "./lib/jsx-runtime/index.js",
+    "./ui": "./lib/ui/index.js"
+  },
   "scripts": {
     "start": "npm run dev",
     "version": "extract version src/version.ts && prettier --write src/version.ts",

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useState, getState, setState } from './useState'


### PR DESCRIPTION
Hello, thanks for the amazing library, We are trying to use this in a project here with `deno`. And we are using `import-maps` and CDN's for the dependencies. 

Currently the project is bundles as `common-js` and exposed using `main` filed. So, the CDN's use this as `entry` and construct a map and expose them to the clients. And  i noticed few modules are not exposed in `package.json`. So, these won't be resolved in serving. 

You can check the `export-map` for the current `nano-jsx` here
https://ga.jspm.io/npm:nano-jsx@0.0.27/package.json

```json
"exports": {
    ".": "./lib/index.js",
    "./lib/index.js": "./lib/index.js",
    "./lib/index.js!cjs": "./lib/index.js"
}
```

## PS

If the maps are merged, if users want to import hooks. They can do by

```jsx
import { useState, getState, setState } from 'nano-jsx/hooks/useState'
```
Instead of 

```jsx
import { useState, getState, setState } from 'nano-jsx/lib/hooks/useState'
```
we can keep it that way too, if the `lib` inside the path is preferred