### PR TITLE
Fixed package.json funding format

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,5 @@
   "engines": {
     "node": ">=12"
   },
-  "funding": {
-    "url": "https://github.com/sponsors/yandeu"
-  }
+  "funding": "https://github.com/sponsors/yandeu"
 }


### PR DESCRIPTION
## Reference Issues/PRs

none

## What does this implement/fix?

- Fixed `package.json` funding format

```js
Object has fewer properties than the required number of 2
```
[
package-json#funding](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#funding)