### PR TITLE
Add route context parameters and pathname to <Route /> children

### DIFF
--- a/deno_lib/components/router.ts
+++ b/deno_lib/components/router.ts
@@ -170,9 +170,12 @@ export const Route: FC<{ path: string; exact?: boolean; regex?: { [param: string
   regex,
   children
 }) => {
-  // pass the path as props to the children
+  // lookup pathname and parameters
+  const pathname = isSSR() ? _nano.location.pathname : window.location.pathname
+  const params = parseParamsFromPath(path)
+  // pass the route as props to the children
   children.forEach((child: any) => {
-    if (child.props) child.props = { ...child.props, route: { path, regex } }
+    if (child.props) child.props = { ...child.props, route: { path, regex, pathname, params } }
   })
   return children
 }

--- a/deno_lib/components/router.ts
+++ b/deno_lib/components/router.ts
@@ -170,12 +170,9 @@ export const Route: FC<{ path: string; exact?: boolean; regex?: { [param: string
   regex,
   children
 }) => {
-  // lookup pathname and parameters
-  const pathname = isSSR() ? _nano.location.pathname : window.location.pathname
-  const params = parseParamsFromPath(path)
-  // pass the route as props to the children
+  // pass the path as props to the children
   children.forEach((child: any) => {
-    if (child.props) child.props = { ...child.props, route: { path, regex, pathname, params } }
+    if (child.props) child.props = { ...child.props, route: { path, regex } }
   })
   return children
 }

--- a/src/components/router.ts
+++ b/src/components/router.ts
@@ -170,9 +170,12 @@ export const Route: FC<{ path: string; exact?: boolean; regex?: { [param: string
   regex,
   children
 }) => {
-  // pass the path as props to the children
+  // lookup pathname and parameters
+  const pathname = isSSR() ? _nano.location.pathname : window.location.pathname
+  const params = parseParamsFromPath(path)
+  // pass the route as props to the children
   children.forEach((child: any) => {
-    if (child.props) child.props = { ...child.props, route: { path, regex } }
+    if (child.props) child.props = { ...child.props, route: { path, regex, pathname, params } }
   })
   return children
 }

--- a/test/browser/router.test.html
+++ b/test/browser/router.test.html
@@ -27,7 +27,7 @@
     <script type="module">
       describe('Simple Router', async () => {
         let Hello = ({ route }) => {
-          return jsx`<div>${route.params.name}</div>`
+          return jsx`<div>${route.pathname}-${route.params.name}</div>`
         }
 
         let App = ({ path }) => {
@@ -54,7 +54,7 @@
 
         to('/hello/world', true)
         await Test.wait()
-        expect(root().firstChild.firstChild.firstChild.textContent).toBe('hello world', 'Navigate to /hello/world')
+        expect(root().firstChild.firstChild.textContent).toBe('/hello/world-world', 'Navigate to /hello/world')
 
         to(href)
       })

--- a/test/browser/router.test.html
+++ b/test/browser/router.test.html
@@ -26,12 +26,17 @@
 
     <script type="module">
       describe('Simple Router', async () => {
+        let Hello = ({ route }) => {
+          return jsx`<div>${route.params.name}</div>`
+        }
+
         let App = ({ path }) => {
           return jsx`        
             <${Switch}>
-							<${Route} exact path="/one">topic one</${Route}>
-							<${Route} exact path="/two">topic two</${Route}>
-							<${Route} path="/">topic overview</${Route}>
+              <${Route} exact path="/one">topic one</${Route}>
+              <${Route} exact path="/two">topic two</${Route}>
+              <${Route} path="/hello/:name"><${Hello} /></${Route}>
+              <${Route} path="/">topic overview</${Route}>
             </${Switch}>`
         }
 
@@ -46,6 +51,10 @@
         to('/two', true)
         await Test.wait()
         expect(root().firstChild.firstChild.textContent).toBe('topic two', 'Navigate to /one (historyReplace)')
+
+        to('/hello/world', true)
+        await Test.wait()
+        expect(root().firstChild.firstChild.firstChild.textContent).toBe('hello world', 'Navigate to /hello/world')
 
         to(href)
       })

--- a/test/nodejs/router.ssr.test.tsx
+++ b/test/nodejs/router.ssr.test.tsx
@@ -25,6 +25,8 @@ test('should render without errors', () => {
     }
   }
 
+  let Hello = (p:any)=> (<div>hello {p.route.params.name}</div>)
+
   class App extends Component {
     render() {
       return (
@@ -41,6 +43,9 @@ test('should render without errors', () => {
             </Router.Route>
             <Router.Route path="/children">
               <Children />
+            </Router.Route>
+            <Router.Route path="/hello/:name">
+              <Hello />
             </Router.Route>
           </Router.Switch>
         </div>
@@ -65,6 +70,9 @@ test('should render without errors', () => {
 
   const regexRoute = renderSSR(<App />, { pathname: '/abc123' })
   expect(regexRoute).toBe('<div id="root"><div><div>Regex Route</div></div></div>')
+
+  const routeParams = renderSSR(<App />, { pathname: '/hello/world' })
+  expect(routeParams).toBe('<div id="root"><div><div>hello world</div></div></div>')
 
   const notFound = renderSSR(<App />, { pathname: '/nothing' })
   expect(notFound).toBe('<div id="root"><div><div>404: Page Not Found</div></div></div>')

--- a/test/nodejs/router.test.tsx
+++ b/test/nodejs/router.test.tsx
@@ -76,6 +76,8 @@ test('should render without errors', async () => {
     }
   }
 
+  let Hello = (p:any)=> (<div>hello {p.route.params.name}</div>)
+
   class App extends Component {
     didMount() {
       setTimeout(() => Router.to('/about'), 200)
@@ -83,7 +85,8 @@ test('should render without errors', async () => {
       setTimeout(() => Router.to('/children/two'), 600)
       setTimeout(() => Router.to('/'), 800)
       setTimeout(() => Router.to('/abc123'), 1000)
-      setTimeout(() => Router.to('/nothing'), 1200)
+      setTimeout(() => Router.to('/hello/world'), 1200)
+      setTimeout(() => Router.to('/nothing'), 1400)
     }
 
     render() {
@@ -101,6 +104,9 @@ test('should render without errors', async () => {
             </Router.Route>
             <Router.Route path="/children">
               <Children />
+            </Router.Route>
+            <Router.Route path="/hello/:name">
+              <Hello />
             </Router.Route>
           </Router.Switch>
         </div>
@@ -131,6 +137,9 @@ test('should render without errors', async () => {
 
   await wait(200)
   expect(nodeToString(res)).toBe('<body><div id="root"><div><div>Regex Route</div></div></div></body>')
+
+  await wait(200)
+  expect(nodeToString(res)).toBe('<body><div id="root"><div><div>hello world</div></div></div></body>')
 
   await wait(200)
   expect(nodeToString(res)).toBe('<body><div id="root"><div><div>404: Page Not Found</div></div></div></body>')


### PR DESCRIPTION
### Reference Issues/PRs

Following up https://github.com/nanojsx/nano/discussions/111

### What does this implement/fix?

Add context properties `pathname` and `params` when using `<Route/>` component, and the type `RouteProps`.

usage:
```tsx
<Router.Switch>
  <Router.Route path="/routing/:id">
    <MyComponent />
  </Router.Route>
</Router.Switch>

function MyComponent({ route }) {
    return <div>id: {route.params.id}</div>
}
```

Actually wondering if the type RouteProps is worth it.