### PR TITLE
Make deno type exports more module freindly

### DIFF
--- a/deno_lib/core.types.ts
+++ b/deno_lib/core.types.ts
@@ -3,27 +3,29 @@
 //   getIterator(): any
 // }
 
-declare var _nano: {
-  document: Document
-  isSSR: true | undefined
-  location: { pathname: string }
-  customElements: Map<string, any>
-  ssrTricks: {
-    isWebComponent: (tagNameOrComponent: any) => boolean
-    renderWebComponent: (tagNameOrComponent: any, props: any, children: any, _render: any) => any
-  }
-}
+declare global {
+  export var _nano: {
+    document: Document;
+    isSSR: true | undefined;
+    location: { pathname: string };
+    customElements: Map<string, any>;
+    ssrTricks: {
+      isWebComponent: (tagNameOrComponent: any) => boolean;
+      renderWebComponent: ( tagNameOrComponent: any, props: any, children: any, _render: any,) => any;
+    };
+  };
 
-declare namespace Deno {}
+  export namespace Deno {}
 
-declare namespace JSX {
-  interface IntrinsicElements {
-    [elemName: string]: any
-  }
-  interface ElementClass {
-    render: any
-  }
-  interface ElementChildrenAttribute {
-    children: any
+  export namespace JSX {
+    interface IntrinsicElements {
+      [elemName: string]: any;
+    }
+    interface ElementClass {
+      render: any;
+    }
+    interface ElementChildrenAttribute {
+      children: any;
+    }
   }
 }

--- a/deno_lib/core.types.ts
+++ b/deno_lib/core.types.ts
@@ -29,3 +29,5 @@ declare global {
     }
   }
 }
+// This export keeps the backward compatibility with the module resolution system in deno < 1.23 version.
+export {}


### PR DESCRIPTION
The newest releases of deno changed module detection behavior,  commit https://github.com/denoland/deno/commit/845d4754c6fb959d1404f5de4bba9e71667b8c89  issue https://github.com/denoland/deno/issues/14960

This pr changes exported types to be more deno module friendly.

I wrote this with guidance from @nayeemrmn