### PR TITLE
fix: text nodes should be taken into account by _render

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,9 @@ npm install
 # build
 npm run build
 
+# bundle
+npm run bundle
+
 # create instrumented bundle
 npx webpack -c webpack/webpack.bundle.instrumented.js
 

--- a/src/bundles/bundle.full.ts
+++ b/src/bundles/bundle.full.ts
@@ -17,6 +17,9 @@ import { Img } from '../components/img.js'
 import { Visible } from '../components/visible.js'
 import * as Router from '../components/router.js'
 
+// customElement
+import { defineAsCustomElements } from '../customElementsMode.js'
+
 // tagged templates
 import { jsx } from '../jsx.js'
 
@@ -43,7 +46,8 @@ export default {
   render,
   task,
   tick,
-  withStyles
+  withStyles,
+  defineAsCustomElements
 }
 
 // version

--- a/src/core.ts
+++ b/src/core.ts
@@ -124,6 +124,9 @@ export const _render = (comp: any): any => {
   // HTMLElement
   if (comp.tagName) return comp
 
+  // TEXTNode
+  if (comp && comp.nodeType === Node.TEXT_NODE) return comp
+
   // Class Component
   if (comp && comp.component && comp.component.isClass) return renderClassComponent(comp)
 
@@ -134,7 +137,7 @@ export const _render = (comp: any): any => {
   if (comp.component && typeof comp.component === 'function') return renderFunctionalComponent(comp)
 
   // Array (render each child and return the array) (is probably a fragment)
-  if (Array.isArray(comp)) return comp.map(c => _render(c)).flat()
+  if (Array.isArray(comp)) return (comp.map(c => _render(c)) as any).flat()
 
   // function
   if (typeof comp === 'function' && !comp.isClass) return _render(comp())
@@ -282,7 +285,7 @@ export const h = (tagNameOrComponent: any, props: any = {}, ...children: any[]) 
   }
 
   // these tags should not be escaped by default (in ssr)
-  const escape = !['noscript', 'script', 'style'].includes(tagNameOrComponent)
+  const escape = !(['noscript', 'script', 'style'] as any).includes(tagNameOrComponent)
   appendChildren(element, children, escape)
 
   if (ref) ref(element)

--- a/src/core.ts
+++ b/src/core.ts
@@ -124,8 +124,8 @@ export const _render = (comp: any): any => {
   // HTMLElement
   if (comp.tagName) return comp
 
-  // TEXTNode
-  if (comp && comp.nodeType === Node.TEXT_NODE) return comp
+  // TEXTNode (Node.TEXT_NODE === 3)
+  if (comp && comp.nodeType === 3) return comp
 
   // Class Component
   if (comp && comp.component && comp.component.isClass) return renderClassComponent(comp)

--- a/src/customElementsMode.ts
+++ b/src/customElementsMode.ts
@@ -1,6 +1,6 @@
 import { h, isSSR, render, _render } from './core.js'
 
-interface CustomElementsParameters {
+export interface CustomElementsParameters {
   mode?: 'open' | 'closed'
   delegatesFocus?: boolean
 }

--- a/test/browser/webComponent.html
+++ b/test/browser/webComponent.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <script src="/tester.js"></script>
+    <script src="/scripts/browserTest/tester.js"></script>
+    <script src="/bundles/nano.instrumented.min.js"></script>
+  </head>
+  <body>
+    <div id="root"></div>
+
+    <script>
+      const { h, render, Component, defineAsCustomElements, Fragment } = nanoJSX
+      const root = document.getElementById('root')
+    </script>
+
+    <script type="module">
+      describe('customElement', async () => {
+        class CustomElementTest extends Component {
+          render() {
+            /* prettier-ignore */
+            return h("div", null,
+              h('h1', null, 'title'),
+              "bye",
+              this.props.children
+            )
+          }
+        }
+
+        defineAsCustomElements(CustomElementTest, 'my-custom-element', [], { mode: 'open' })
+
+        const App = () => h('div', null, h('my-custom-element', null, 'hello'))
+
+        render(App, root, false)
+
+        const myCustomElement = document.querySelector('my-custom-element')
+
+        Test.error(root.innerHTML === '<div><my-custom-element>hello</my-custom-element></div>')
+
+        Test.error(myCustomElement?.shadowRoot?.innerHTML === '<div><div><h1>title</h1>bye</div></div>')
+      })
+
+      Test.start()
+    </script>
+  </body>
+</html>

--- a/test/browser/webComponent.html
+++ b/test/browser/webComponent.html
@@ -6,39 +6,55 @@
     <script src="/tester.js"></script>
     <script src="/scripts/browserTest/tester.js"></script>
     <script src="/bundles/nano.instrumented.min.js"></script>
-  </head>
-  <body>
-    <div id="root"></div>
-
     <script>
       const { h, render, Component, defineAsCustomElements, Fragment } = nanoJSX
       const root = document.getElementById('root')
     </script>
 
     <script type="module">
-      describe('customElement', async () => {
-        class CustomElementTest extends Component {
-          render() {
-            /* prettier-ignore */
-            return h("div", null,
+      class CustomElementTest extends Component {
+        render() {
+          /* prettier-ignore */
+          return h("div", null,
               h('h1', null, 'title'),
               "bye",
-              this.props.children
+              this.props.children, // renders nothing
+              this.props.hello, // renders 123
             )
-          }
         }
+      }
 
-        defineAsCustomElements(CustomElementTest, 'my-custom-element', [], { mode: 'open' })
+      const SlotTest = () => {
+        return h('p', null, 'Hello: ', h('slot', { name: 'username' }))
+      }
 
-        const App = () => h('div', null, h('my-custom-element', null, 'hello'))
+      defineAsCustomElements(CustomElementTest, 'my-custom-element', ['hello'], { mode: 'open' })
+      defineAsCustomElements(SlotTest, 'slot-test', [], { mode: 'open' })
+    </script>
+  </head>
+  <body>
+    <div id="root">
+      <my-custom-element hello="123">invisible</my-custom-element>
+      <slot-test><span slot="username">John Doe</span></slot-test>
+    </div>
 
-        render(App, root, false)
-
+    <script type="module">
+      describe('my-custom-element', async () => {
         const myCustomElement = document.querySelector('my-custom-element')
+        Test.error(myCustomElement.innerHTML === 'invisible', 'Should show text "invisible"')
+        Test.error(
+          myCustomElement?.shadowRoot?.innerHTML === '<div><div><h1>title</h1>bye123</div></div>',
+          'Shadow should contain "title" and "bye123"'
+        )
+      })
 
-        Test.error(root.innerHTML === '<div><my-custom-element>hello</my-custom-element></div>')
-
-        Test.error(myCustomElement?.shadowRoot?.innerHTML === '<div><div><h1>title</h1>bye</div></div>')
+      describe('slot-test', async () => {
+        const myCustomElement = document.querySelector('slot-test')
+        Test.error(myCustomElement.innerHTML === '<span slot="username">John Doe</span>', 'Should show span')
+        Test.error(
+          myCustomElement?.shadowRoot?.innerHTML === '<div><p>Hello: <slot name="username"></slot></p></div>',
+          'Hello: John Doe'
+        )
       })
 
       Test.start()


### PR DESCRIPTION
_render is not taken text nodes into account. this leads to situations like this: imagine the following component

```jsx
    return (
      <>
        <h1>{this.data.count}</h1>

        <button onclick={() => this.data.count--}>
          Dec
        </button>
        
        <button onclick={() => this.data.count++}>
          Inc
        </button>

        { this.props.children }      
      </>
    )
```

note that the { children } are the last node collection. now imagine that we called this component like this:

```html
  <MyComponent>
      asdf
  </MyComponent>
```

we will get this result:

```html
<my-custom-element>
    asdf
  <h1>0</h1>
  <button>Dec</button>
  <button>Inc</button>
</my-custom-element>
```

im having this problem using the "web component mode" because of this part of the code:

```js
        /** customElementsMode.ts - Line 43 **/
        const children = Array.from(this.children).map(c => render(c))

        // because nano-jsx update need parentElement, so DocumentFragment is not usable...
        const el = h(
          'div',
          null,
          _render({
            component,
            props: {
              children: children,
              ref: (r: any) => (ref = r)
            }
          })
        )
```

the _render will be called and wont see the text node which will be ignored by the handles.
obs: im not sure if its possible to use Node.TEXT_NODE here taking different envs into account, but would be the safer way.