### PR TITLE
When in "Custom Elements Mode", Shadow Dom should be configurable and optional

### DIFF
--- a/src/customElementsMode.ts
+++ b/src/customElementsMode.ts
@@ -35,7 +35,7 @@ export const defineAsCustomElements: (
 
         if (shadow) {
           this.attachShadow(shadow);
-          this.$root = this.$root as ShadowRoot;
+          this.$root = this.shadowRoot as ShadowRoot;
         } else {
           this.$root = this;
         }

--- a/src/customElementsMode.ts
+++ b/src/customElementsMode.ts
@@ -26,7 +26,7 @@ export const defineAsCustomElements: (
     componentName,
     class extends HTMLElement {
       component: any
-      $root: ShadowRoot|HTMLElement;
+      $root: ShadowRoot | HTMLElement
       private isFunctionalComponent: boolean
       private functionalComponentsProps: any
 
@@ -34,10 +34,10 @@ export const defineAsCustomElements: (
         super()
 
         if (shadow) {
-          this.attachShadow(shadow);
-          this.$root = this.shadowRoot as ShadowRoot;
+          this.attachShadow(shadow)
+          this.$root = this.shadowRoot as ShadowRoot
         } else {
-          this.$root = this;
+          this.$root = this
         }
 
         let ref
@@ -56,7 +56,7 @@ export const defineAsCustomElements: (
         this.component = ref
         this.isFunctionalComponent = !component.isClass
         this.functionalComponentsProps = {}
-        this.appendEl(el);
+        this.appendEl(el)
         // ------------------------------------------
 
         if (!this.isFunctionalComponent) {
@@ -76,15 +76,15 @@ export const defineAsCustomElements: (
       private buildEl(contents: any) {
         // because nano-jsx update needs parentElement, we need
         // to wrap the element in a div when using shadow mode
-        return h(!!this.shadowRoot ? 'div' : 'template', null, contents);
+        return h(this.shadowRoot ? 'div' : 'template', null, contents)
       }
 
       private appendEl(el: any) {
-        if (!!this.shadowRoot) {
-          el.dataset.wcRoot = true;
-          this.$root.append(el);
+        if (this.shadowRoot) {
+          el.dataset.wcRoot = true
+          this.$root.append(el)
         } else {
-          this.$root.append(...el.childNodes);
+          this.$root.append(...el.childNodes)
         }
       }
 
@@ -104,7 +104,7 @@ export const defineAsCustomElements: (
         } else {
           this.removeChildren()
           this.functionalComponentsProps[name] = newValue
-          
+
           const el = this.buildEl(
             _render({
               component,

--- a/src/customElementsMode.ts
+++ b/src/customElementsMode.ts
@@ -81,7 +81,7 @@ export const defineAsCustomElements: (
 
       private appendEl(el: any) {
         if (this.shadowRoot) {
-          el.dataset.wcRoot = true
+          // el.dataset.wcRoot = true
           this.$root.append(el)
         } else {
           this.$root.append(...el.childNodes)

--- a/src/customElementsMode.ts
+++ b/src/customElementsMode.ts
@@ -1,10 +1,5 @@
 import { h, isSSR, render, _render } from './core.js'
 
-interface CustomElementsParameters {
-  mode?: 'open' | 'closed'
-  delegatesFocus?: boolean
-}
-
 const defineAsCustomElementsSSR = (
   component: any,
   componentName: string,
@@ -20,8 +15,8 @@ export const defineAsCustomElements: (
   component: any,
   componentName: string,
   publicProps: string[],
-  params?: CustomElementsParameters
-) => void = function (component, componentName, publicProps, { mode = 'closed', delegatesFocus = false } = {}) {
+  shadow?: ShadowRootInit
+) => void = function (component, componentName, publicProps, shadow) {
   if (isSSR()) {
     defineAsCustomElementsSSR(component, componentName, publicProps)
     return
@@ -31,34 +26,39 @@ export const defineAsCustomElements: (
     componentName,
     class extends HTMLElement {
       component: any
+      $root: ShadowRoot|HTMLElement;
       private isFunctionalComponent: boolean
       private functionalComponentsProps: any
 
       constructor() {
         super()
 
-        const shadowRoot = this.attachShadow({ mode, delegatesFocus })
+        if (shadow) {
+          this.attachShadow(shadow);
+          this.$root = this.$root as ShadowRoot;
+        } else {
+          this.$root = this;
+        }
 
         let ref
-        const children = Array.from(this.children).map(c => render(c))
 
-        // because nano-jsx update need parentElement, so DocumentFragment is not usable...
-        const el = h(
-          'div',
-          null,
+        const el = this.buildEl(
           _render({
             component,
             props: {
-              children: children,
-              ref: (r: any) => (ref = r)
+              ref: (r: any) => (ref = r),
+              children: Array.from(this.children).map(c => render(c))
             }
           })
         )
+
+        // ------------------------------ first render
         this.component = ref
         this.isFunctionalComponent = !component.isClass
         this.functionalComponentsProps = {}
+        this.appendEl(el);
+        // ------------------------------------------
 
-        shadowRoot.append(el)
         if (!this.isFunctionalComponent) {
           this.component.updatePropsValue = (name: string, value: any) => {
             // @ts-ignore
@@ -73,9 +73,24 @@ export const defineAsCustomElements: (
         return publicProps
       }
 
+      private buildEl(contents: any) {
+        // because nano-jsx update needs parentElement, we need
+        // to wrap the element in a div when using shadow mode
+        return h(!!this.shadowRoot ? 'div' : 'template', null, contents);
+      }
+
+      private appendEl(el: any) {
+        if (!!this.shadowRoot) {
+          el.dataset.wcRoot = true;
+          this.$root.append(el);
+        } else {
+          this.$root.append(...el.childNodes);
+        }
+      }
+
       private removeChildren() {
-        if (this.shadowRoot) {
-          const children = Array.from(this.shadowRoot?.children) || []
+        if (this.$root) {
+          const children = Array.from(this.$root?.children) || []
           for (const el of children) {
             el.remove()
           }
@@ -89,9 +104,8 @@ export const defineAsCustomElements: (
         } else {
           this.removeChildren()
           this.functionalComponentsProps[name] = newValue
-          const el = h(
-            'div',
-            null,
+          
+          const el = this.buildEl(
             _render({
               component,
               props: {
@@ -101,7 +115,8 @@ export const defineAsCustomElements: (
               }
             })
           )
-          this.shadowRoot!.append(el)
+
+          this.appendEl(el)
         }
       }
     }

--- a/test/nodejs/customElementsMode.test.tsx
+++ b/test/nodejs/customElementsMode.test.tsx
@@ -10,7 +10,7 @@ afterEach(async () => {
   await wait()
 })
 
-test('should render as web components', async () => {
+test('should render as web components (without shadow DOM)', async () => {
   class Test extends Component {
     render() {
       return <div>test</div>
@@ -21,7 +21,9 @@ test('should render as web components', async () => {
   document.body.innerHTML = '<nano-test1></nano-test1>'
 
   await wait()
-  expect(document.body.outerHTML).toBe('<body><nano-test1></nano-test1></body>')
+  const comp = document.querySelector('nano-test1')
+  expect(comp?.outerHTML).toBe('<nano-test1><div>test</div></nano-test1>')
+  expect(comp?.shadowRoot).toBeNull()
   expect(spy).not.toHaveBeenCalled()
 })
 


### PR DESCRIPTION
## This PR aims to solve:

- Shadow DOM is optional and disabled by default in vanilla JavaScript Web Components. So, the same should be applied to Nano when in "Custom Elements Mode": https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM

- { delegatesFocus } is a ShadowDOM attachment option and should be part of shadow dom configuration and not a separated config. Also other options can be applied: https://developer.mozilla.org/en-US/docs/Web/API/Element/attachShadow

- Force a wrapper to the content of the component is only necessary when in shadow dom mode, when not, the component and the nano updates will be applied correctly without a forced wrapper (div)

## Breaking Changes

This PR adds a breaking change to the "Shadow DOM Mode" feature

## New Usage

On the current version, you can register a nano element as a web component with this API

```js
defineAsCustomElements(
  CustomElementCounter, // nano component
  'custom-element-counter', // wc name
  [], // props
  // optional attach a shadow DOM mode to a custom element: open / closed
  // more info:
  // https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_shadow_DOM
  // PROBLEM: if you omit this option the component will be created with a shadow dom anyway
  { mode: 'open' } // shadow dom mode
)
```

The new usage will add this behavior

```js
// This will create a simple custom web component without shadow dom (as the spec)
// this is lighter and easier to work with (ignoring styling caveats that can be easily solved)

defineAsCustomElements(CustomElementCounter, 'custom-element-counter');
```

This will attach a shadow dom

```js
// This will create a simple custom web component without shadow dom (as the spec)
// this is lighter and easier to work with (ignoring styling caveats that can be easily solved)

defineAsCustomElements(
  CustomElementCounter, 
  'custom-element-counter', 
  [], 
  { mode: 'open', ... /** add any other shadow option here, like an original wc **/ }
)
```

This behavior will drive the nano Custom Elements API to behave like a vanilla web component, making it more familiar and easier to configure.

## TODO

If the PR gets approved, I must update the docs