### PR TITLE
Exports initSSR

### DIFF
--- a/deno_lib/index.ts
+++ b/deno_lib/index.ts
@@ -18,7 +18,7 @@ export { isSSR }
 export { jsx } from './jsx.ts'
 export { hydrateLazy } from './lazy.ts'
 export { nodeToString, task } from './helpers.ts'
-export { renderSSR } from './ssr.ts'
+export { renderSSR, initSSR } from './ssr.ts'
 export { Fragment } from './fragment.ts'
 export { Store } from './store.ts'
 export { createContext, useContext } from './context.ts'

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,7 +18,7 @@ export { isSSR }
 export { jsx } from './jsx.js'
 export { hydrateLazy } from './lazy.js'
 export { nodeToString, task } from './helpers.js'
-export { renderSSR } from './ssr.js'
+export { renderSSR, initSSR } from './ssr.js'
 export { Fragment } from './fragment.js'
 export { Store } from './store.js'
 export { createContext, useContext } from './context.js'


### PR DESCRIPTION
Exports `initSSR` to help when occurs `document is not defined` with `renderSSR`

I'm using Vite to build my SSR application and `initSSR` is missing in exports, causing incorrectly bundle build