### PR TITLE
Feature: Shadow DOM without wrapping DIV element

### DIFF
--- a/.github/workflows/browser.yml
+++ b/.github/workflows/browser.yml
@@ -37,7 +37,7 @@ jobs:
           rm -f package.json
           rm -f package-lock.json
           npm init -y
-          npm i -D rimraf typescript puppeteer
+          npm i -D rimraf typescript@5.1.6 puppeteer
           npm i -D webpack webpack-cli ts-loader nyc coverage-istanbul-loader
 
       - name: Prepare

--- a/src/component.ts
+++ b/src/component.ts
@@ -114,7 +114,7 @@ export class Component<P extends Object = any, S = any> {
     // console.log('new: ', this.elements)
 
     // get valid parent node
-    const parent = oldElements[0].parentElement as HTMLElement
+    const parent = oldElements[0].parentNode as DocumentFragment
 
     // make sure we have a parent
     if (!parent) console.warn('Component needs a parent element to get updated!')

--- a/src/component.ts
+++ b/src/component.ts
@@ -114,7 +114,7 @@ export class Component<P extends Object = any, S = any> {
     // console.log('new: ', this.elements)
 
     // get valid parent node
-    const parent = oldElements[0].parentNode as DocumentFragment
+    const parent = oldElements[0].parentNode
 
     // make sure we have a parent
     if (!parent) console.warn('Component needs a parent element to get updated!')

--- a/src/customElementsMode.ts
+++ b/src/customElementsMode.ts
@@ -74,18 +74,11 @@ export const defineAsCustomElements: (
       }
 
       private buildEl(contents: any) {
-        // because nano-jsx update needs parentElement, we need
-        // to wrap the element in a div when using shadow mode
-        return h(this.shadowRoot ? 'div' : 'template', null, contents)
+        return h('template', null, contents)
       }
 
       private appendEl(el: any) {
-        if (this.shadowRoot) {
-          // el.dataset.wcRoot = true
-          this.$root.append(el)
-        } else {
-          this.$root.append(...el.childNodes)
-        }
+        this.$root.append(...el.childNodes)
       }
 
       private removeChildren() {

--- a/test/browser/webComponent.html
+++ b/test/browser/webComponent.html
@@ -43,7 +43,7 @@
         const myCustomElement = document.querySelector('my-custom-element')
         Test.error(myCustomElement.innerHTML === 'invisible', 'Should show text "invisible"')
         Test.error(
-          myCustomElement?.shadowRoot?.innerHTML === '<div><div><h1>title</h1>bye123</div></div>',
+          myCustomElement?.shadowRoot?.innerHTML === '<div><h1>title</h1>bye123</div>',
           'Shadow should contain "title" and "bye123"'
         )
       })
@@ -52,7 +52,7 @@
         const myCustomElement = document.querySelector('slot-test')
         Test.error(myCustomElement.innerHTML === '<span slot="username">John Doe</span>', 'Should show span')
         Test.error(
-          myCustomElement?.shadowRoot?.innerHTML === '<div><p>Hello: <slot name="username"></slot></p></div>',
+          myCustomElement?.shadowRoot?.innerHTML === '<p>Hello: <slot name="username"></slot></p>',
           'Hello: John Doe'
         )
       })

--- a/test/browser/webComponent.html
+++ b/test/browser/webComponent.html
@@ -46,6 +46,13 @@
           myCustomElement?.shadowRoot?.innerHTML === '<div><h1>title</h1>bye123</div>',
           'Shadow should contain "title" and "bye123"'
         )
+        
+        // update attribute hello
+        myCustomElement.setAttribute("hello", 456)
+        Test.error(
+          myCustomElement?.shadowRoot?.innerHTML === '<div><h1>title</h1>bye456</div>',
+          'Shadow should contain "title" and "bye456"'
+        )
       })
 
       describe('slot-test', async () => {

--- a/test/nodejs/customElementsMode.test.tsx
+++ b/test/nodejs/customElementsMode.test.tsx
@@ -40,7 +40,7 @@ test('should render with correct content', async () => {
   await wait()
 
   const comp = document.querySelector('nano-test2')
-  expect(comp?.shadowRoot?.innerHTML).toEqual('<div><div>test text</div></div>')
+  expect(comp?.shadowRoot?.innerHTML).toEqual('<div>test text</div>')
   expect(spy).not.toHaveBeenCalled()
 })
 
@@ -65,7 +65,7 @@ test('should render with props', async () => {
   await wait()
 
   const comp = document.querySelector('nano-test3')
-  expect(comp?.shadowRoot?.innerHTML).toEqual('<div><div>test : fuga</div></div>')
+  expect(comp?.shadowRoot?.innerHTML).toEqual('<div>test : fuga</div>')
   expect(spy).not.toHaveBeenCalled()
 })
 
@@ -90,11 +90,11 @@ test('should update render result with props change', async () => {
   await wait()
 
   const comp = document.querySelector('nano-test4')
-  expect(comp?.shadowRoot?.innerHTML).toEqual('<div><div>test : fuga</div></div>')
+  expect(comp?.shadowRoot?.innerHTML).toEqual('<div>test : fuga</div>')
 
   document.body.innerHTML = '<nano-test4 value="hoge"></nano-test4>'
   const compChanged = document.querySelector('nano-test4')
-  expect(compChanged?.shadowRoot?.innerHTML).toEqual('<div><div>test : hoge</div></div>')
+  expect(compChanged?.shadowRoot?.innerHTML).toEqual('<div>test : hoge</div>')
   expect(spy).not.toHaveBeenCalled()
 })
 
@@ -123,10 +123,10 @@ test('should change render result with state change', async () => {
   await wait()
 
   const comp = document.querySelector('nano-test5')
-  expect(comp?.shadowRoot?.innerHTML).toEqual('<div><div><div>Counter: 0</div><button>Increment</button></div></div>')
+  expect(comp?.shadowRoot?.innerHTML).toEqual('<div><div>Counter: 0</div><button>Increment</button></div>')
 
   comp?.shadowRoot?.querySelector('button')?.click()
-  expect(comp?.shadowRoot?.innerHTML).toEqual('<div><div><div>Counter: 1</div><button>Increment</button></div></div>')
+  expect(comp?.shadowRoot?.innerHTML).toEqual('<div><div>Counter: 1</div><button>Increment</button></div>')
   expect(spy).not.toHaveBeenCalled()
 })
 
@@ -163,17 +163,17 @@ test('should keep state with props change', async () => {
 
   const comp = document.querySelector('nano-test6')
   expect(comp?.shadowRoot?.innerHTML).toEqual(
-    '<div><div><div>Counter: 0</div><div>props: 1</div><button>Increment</button></div></div>'
+    '<div><div>Counter: 0</div><div>props: 1</div><button>Increment</button></div>'
   )
 
   comp?.shadowRoot?.querySelector('button')?.click()
   expect(comp?.shadowRoot?.innerHTML).toEqual(
-    '<div><div><div>Counter: 1</div><div>props: 1</div><button>Increment</button></div></div>'
+    '<div><div>Counter: 1</div><div>props: 1</div><button>Increment</button></div>'
   )
   // @ts-ignore
   comp.attributes.value?.value = 2
   expect(comp?.shadowRoot?.innerHTML).toEqual(
-    '<div><div><div>Counter: 1</div><div>props: 2</div><button>Increment</button></div></div>'
+    '<div><div>Counter: 1</div><div>props: 2</div><button>Increment</button></div>'
   )
   expect(spy).not.toHaveBeenCalled()
 })
@@ -190,10 +190,10 @@ test('should render also with functional component', async () => {
   await wait()
 
   const comp = document.querySelector('nano-test7')
-  expect(comp?.shadowRoot?.innerHTML).toEqual('<div><p>hoge</p></div>')
+  expect(comp?.shadowRoot?.innerHTML).toEqual('<p>hoge</p>')
   // @ts-ignore
   comp.attributes.value?.value = 'bar'
-  expect(comp?.shadowRoot?.innerHTML).toEqual('<div><p>bar</p></div>')
+  expect(comp?.shadowRoot?.innerHTML).toEqual('<p>bar</p>')
   expect(spy).not.toHaveBeenCalled()
 })
 
@@ -225,6 +225,6 @@ test('should render also with slot', async () => {
   await wait()
 
   const comp = document.querySelector('nano-test8')
-  expect(comp?.shadowRoot?.innerHTML).toEqual('<div><div><header>nano jsx</header><main><p>hoge</p></main></div></div>')
+  expect(comp?.shadowRoot?.innerHTML).toEqual('<div><header>nano jsx</header><main><p>hoge</p></main></div>')
   expect(spy).not.toHaveBeenCalled()
 })


### PR DESCRIPTION
## Background

I was playing arround with NanoJSX and found in case of using it to create WebCompontents it did wrap them into a `div` element because `Component.update()` expects the parent to be `Element`. This adds more elements to the DOM than needed and is not expected to happen when creating a WebComponent.

## Changes

I did a small change to `Component.update()` to get the parent via `oldElements[0].parentNode` instead of `oldElements[0].parentElement`. I then removed the shadowroot conditions in `class.buildEl()` and `class.appendEl()` in `defineAsCustomElements()`.

## Tests

The tests are fixed by removing the wrapping `<div>` tags. I could **not** run the e2e tests localy. I only checked if it still works in my local project by mounting a component and do frequent `update()` calls.

## Breaking Changes

This PR adds a breaking change to the "Shadow DOM" feature if someone expects the wrapping `div` to be rendered.