### PR TITLE
Feature: Add Bun.js support

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "./jsx-runtime": "./jsx-runtime/index.js",
     "./lib/jsx-runtime": "./lib/jsx-runtime/index.js",
     "./esm/jsx-runtime": "./esm/jsx-runtime/index.js",
+    "./esm/jsx-dev-runtime": "./esm/jsx-runtime/index.js",
     "./*": "./*"
   },
   "scripts": {

--- a/src/jsx-runtime/index.ts
+++ b/src/jsx-runtime/index.ts
@@ -11,3 +11,4 @@ const createNode: (type: any, props: any, key: string, source?: string, self?: s
 export { createNode as jsx }
 export { createNode as jsxs }
 export { createNode as jsxDev }
+export { createNode as jsxDEV }


### PR DESCRIPTION
In Bun.js v1.2.19, importing nano-jsx@0.1.0 and running bun run --watch does not work properly and results in the following error:

```
error: Cannot find module 'nano-jsx/lib/jsx-dev-runtime' from 'D:\Desktop\workspace\bun-hono-template\src\core\response\react-ssr.res.tsx'
```

And

```
SyntaxError: Export named 'jsxDEV' not found in module 'D:\Desktop\workspace\bun-hono-template\node_modules\nano-jsx\esm\jsx-runtime\index.js'.
       at loadAndEvaluateModule (1:11)
```

The issue was caused by the missing jsx-dev-runtime. I have fixed this problem and verified it works with [@lanten233/nano-jsx
](https://www.npmjs.com/package/@lanten233/nano-jsx). 

Please evaluate its impact.